### PR TITLE
Add world transportation service to imagery basemap in setBasemap function

### DIFF
--- a/samples/esri-leaflet/esri-leaflet.html
+++ b/samples/esri-leaflet/esri-leaflet.html
@@ -165,7 +165,8 @@
     var map = L.map('map', {zoomControl: false}).setView([45.52, -122.68], 12),
       layer = L.esri.basemapLayer('NationalGeographic').addTo(map),
       // layerLabels = L.esri.basemapLayer('xxxLabels').addTo(map);
-      layerLabels = null;
+      layerLabels = null,
+      worldTransportation = L.esri.basemapLayer('ImageryTransportation');      
 
     function setBasemap(basemap) {
       if (layer) {
@@ -185,6 +186,14 @@
       if (basemap === 'ShadedRelief' || basemap === 'Oceans' || basemap === 'Gray' || basemap === 'DarkGray' || basemap === 'Imagery' || basemap === 'Terrain') {
         layerLabels = L.esri.basemapLayer(basemap + 'Labels');
         map.addLayer(layerLabels);
+      }
+        
+      // add world transportation service to Imagery basemap
+      if (basemap === 'Imagery') {
+        worldTransportation.addTo(map);            
+      } else if (map.hasLayer(worldTransportation)) {
+        // remove world transportation if Imagery basemap is not selected    
+        map.removeLayer(worldTransportation);
       }
     }
 


### PR DESCRIPTION
I've added a conditional at the end of the setBasemap function to add the World Transportation service to the map if the Imagery basemap is selected.

If the Imagery basemap was not selected, and the World Transportation service is added to the map, it is removed.  This prevents a conflict of having this service with other basemaps.

Perhaps it would be better to comment out this code to show that it is possible?  I've noticed there are comments elsewhere in the example.