### PR TITLE
Fixed typo in class name in style explorer

### DIFF
--- a/samples/style-explorer/index.html
+++ b/samples/style-explorer/index.html
@@ -304,7 +304,7 @@
             </div>
           </div>
           <a class="left carousel-control" href="#carousel-example-generic" role="button" data-slide="prev">
-          <span class="ntglyphicon glyphicon-chevron-left" aria-hidden="true"></span>
+          <span class="glyphicon glyphicon-chevron-left" aria-hidden="true"></span>
           <span class="sr-only">Previous</span>
           </a>
           <a class="right carousel-control" href="#carousel-example-generic" role="button" data-slide="next">


### PR DESCRIPTION
left error glyphicon wasn't loading due to class being incorrectly entered as "ntglyphicon".