### PR TITLE
Fix panel toggle collapsing all descendant panels

### DIFF
--- a/dist/js/jquery/calcitemaps-v0.3.js
+++ b/dist/js/jquery/calcitemaps-v0.3.js
@@ -33,13 +33,13 @@
 
     // Toggle panels
     if (isPanel) {
-      panelBody = panel.find(".panel-collapse");
+      panelBody = panel.children(".panel-collapse");
       if (!panel.hasClass("in")) {
         // Close panels
         panels = $(".calcite-panels .panel.in"); //.not(e.currentTarget.dataset.target);
         panels.collapse("hide");
         // Close bodies
-        panels.find(".panel-collapse").collapse("hide");
+        panels.children(".panel-collapse").collapse("hide");
         // Show panel
         panel.collapse("show");
         // Show body

--- a/lib/js/jquery/calcitemaps.js
+++ b/lib/js/jquery/calcitemaps.js
@@ -33,13 +33,13 @@
 
     // Toggle panels
     if (isPanel) {
-      panelBody = panel.find(".panel-collapse");
+      panelBody = panel.children(".panel-collapse");
       if (!panel.hasClass("in")) {
         // Close panels
         panels = $(".calcite-panels .panel.in"); //.not(e.currentTarget.dataset.target);
         panels.collapse("hide");
         // Close bodies
-        panels.find(".panel-collapse").collapse("hide");
+        panels.children(".panel-collapse").collapse("hide");
         // Show panel
         panel.collapse("show");
         // Show body


### PR DESCRIPTION
Working with the jquery version, I noticed that every descendant panel was also being expanded when toggling the main panels. This does not happen in the dojo version as far as I know.