### PR TITLE
Fix/dojo-bootstrap-tab-issue 

### DIFF
--- a/dist/js/dojo/calcitemaps-v0.4.js
+++ b/dist/js/dojo/calcitemaps-v0.4.js
@@ -36,6 +36,8 @@ define([
 
     activePanel: null,
 
+    activeMenuItem: null,
+    
     stickyDropdownDesktop: false,
 
     stickyDropdownMobile: false,
@@ -73,6 +75,13 @@ define([
           panels = null;
 
         if (e.currentTarget.dataset.target) {
+          //toggle active status for menu items
+          var menuItem = query(e.currentTarget);
+          menuItem.closest('li').addClass('active');
+          if (this.activeMenuItem) {           
+            this.activeMenuItem.closest('li').removeClass('active');           
+          }
+          this.activeMenuItem = menuItem;
           panel = query(e.currentTarget.dataset.target);
           if (panel.length > 0) {
             isPanel = domClass.contains(panel[0], "panel");

--- a/lib/js/dojo/calcitemaps.js
+++ b/lib/js/dojo/calcitemaps.js
@@ -36,6 +36,8 @@ define([
 
     activePanel: null,
 
+    activeMenuItem: null,
+    
     stickyDropdownDesktop: false,
 
     stickyDropdownMobile: false,
@@ -73,6 +75,13 @@ define([
           panels = null;
 
         if (e.currentTarget.dataset.target) {
+          //toggle active status for menu items
+          var menuItem = query(e.currentTarget);
+          menuItem.closest('li').addClass('active');
+          if (this.activeMenuItem) {           
+            this.activeMenuItem.closest('li').removeClass('active');           
+          }
+          this.activeMenuItem = menuItem;
           panel = query(e.currentTarget.dataset.target);
           if (panel.length > 0) {
             isPanel = domClass.contains(panel[0], "panel");


### PR DESCRIPTION
I've been looking into an issue with dropdown menu items with the data-toggle="tab" attr staying highlighted indefinitely after clicked in a CMV application. The issue #158  seems to relate this to a dojo issue within the dijit MenuItem class. 

While that solution may work, I've looked into it further and it looks like it's simply an issue with dojo-bootstrap Tab.js not selecting the dropdown-menu container by design (Tab.js line 40). You can test this by adding the data-toggle="tab" attr to any anchor element in the dropdown menu, which would normally be the way to manage tab (or panel) active state in bootstrap. 
But we are using a dropdown menu and not 'tabs' in the bootstrap sense, so menu items will stay active because Tab is ignoring the parent <ul class="dropdown-menu"> container. Again, this is by design based on how bootstrap tabs work normally. 

So to emulate the active state management of tabs in bootstrap, it means that in addition to managing the active state of panels, we should manage the menu item active state as well. 

