### PR TITLE
Extra commas in SCSS

### DIFF
--- a/lib/sass/layouts/large-title.scss
+++ b/lib/sass/layouts/large-title.scss
@@ -132,7 +132,7 @@ $navbar_nav_li_a_padding: 20px 15px;
         .calcite-panels {
           top: $navbar_height + $base_ui_margin;
         }
-      },
+      }
       &.calcite-nav-bottom {
         .calcite-panels {
           top: $base_ui_margin + $base_ui_margin;

--- a/lib/sass/layouts/small-title.scss
+++ b/lib/sass/layouts/small-title.scss
@@ -137,7 +137,7 @@ $navbar_nav_li_a_padding: 10px 12px;
         .calcite-panels {
           top: $navbar_height + $base_ui_margin;
         }
-      },
+      }
       &.calcite-nav-bottom {
         .calcite-panels {
           top: $base_ui_margin + $base_ui_margin;


### PR DESCRIPTION
Small fix to address errors when working with a more recent version of the sass compiler.  For example:

```cmd
Running "sass:build" (sass) task
>> Error: Invalid CSS after "      }": expected selector, was ","
>>         on line 140 of src/vendor/calcite-maps/lib/sass/layouts/small-title.scss
>>         from line 11 of src/scss/style.scss
>> >>       },
>>
>>    -------^
Warning:  Use --force to continue.

Aborted due to warnings.
```
