### PR TITLE
Fix datepicker destroy method in dojo-bootstrap

### DIFF
--- a/dist/vendor/dojo-bootstrap/Datepicker.js
+++ b/dist/vendor/dojo-bootstrap/Datepicker.js
@@ -389,7 +389,6 @@ define([
         },
         destroy: function (e) {
             support.removeData(this.domNode, "datepicker");
-            this.nodeEvent.remove();
             domConstruct.destroy(this.picker);
         }
     });


### PR DESCRIPTION
The nodeEvent property is never defined as far as I can tell...